### PR TITLE
Read functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,14 @@ Three A's:
 
 ### Read Functionality 
 Read functionality is concerned with just displaying information: CatIndex, CatShow
+
+To use dynamic rendering on routes: use attribute `render` instead of `component`.
+`render` takes a function that should return a component
+
+In order to access URL params, use React-Route `match` object on `props`
+e.g. `props.match.params.<:url_param>`
+Documentation: [https://reactrouter.com/web/api/match](https://reactrouter.com/web/api/match
+)
+
+React's "key" prop warning: use a unique identifier to help React determine which items need to be rerendered
+

--- a/README.md
+++ b/README.md
@@ -38,3 +38,7 @@ Three A's:
 // act - user interaction
 
 // assert - expectation of component behavior
+
+
+### Read Functionality 
+Read functionality is concerned with just displaying information: CatIndex, CatShow

--- a/src/App.js
+++ b/src/App.js
@@ -14,18 +14,39 @@ import {
 } from 'react-router-dom'
 
 import './App.css'
-// import cats from './mockCats.js'
+import cats from './mockCats.js'
 
 
 class App extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      cats: cats
+    }
+  }
+
   render() {
     return (
       <Router>
         <Header />
         <Switch>
           <Route exact path="/" component={ Home } />
-          <Route path="/catindex" component = { CatIndex } />
-          <Route path="/catshow" component = { CatShow } />
+          <Route 
+            path="/catindex" 
+            render = { () => <CatIndex cats={this.state.cats}/> } 
+          />
+          {/* <Route path="/catindex" component = { CatIndex } /> */}
+          
+          {/* <Route path="/catshow" component = { CatShow } /> */}
+          <Route path="/catshow/:id" render = {(props) => {
+            // get the id from the URL
+            // const id = parseInt(props.match.params.id);
+            const id = +props.match.params.id;
+            // find the cat from mockData with the id
+            const foundKitty = this.state.cats.find(cat => cat.id === id);
+            // pass that cat into CatShow as propData
+            return <CatShow cat={foundKitty}/>}
+          } />
           <Route path="/catnew" component = { CatNew } />
           <Route path="/catedit" component = { CatEdit } />
           <Route component = { NotFound } />

--- a/src/pages/CatIndex.js
+++ b/src/pages/CatIndex.js
@@ -5,6 +5,15 @@ class CatIndex extends Component {
     return (
       <>
         <h2>Index</h2>
+        <ul>
+          {this.props.cats.map(cat => {
+            return (
+              <li key={cat.id}>
+                <a href={`/catshow/${cat.id}`}>{cat.name}</a>
+              </li>
+            )
+          })}
+        </ul>
       </>
     )
   }

--- a/src/pages/CatShow.js
+++ b/src/pages/CatShow.js
@@ -2,9 +2,15 @@ import React, { Component } from 'react'
 
 class CatShow extends Component {
   render() {
+    const cat = this.props.cat;
+    console.log(cat)
     return (
       <>
         <h2>Show</h2>
+
+        <div>Name: {cat.name}</div>
+        <div>Age: {cat.age}</div>
+        <div>Enjoys: {cat.enjoys}</div>
       </>
     )
   }


### PR DESCRIPTION
Add props to CatIndex and CatShow
Users can see a list of cat names on CatIndex and when they click on a name, it navigates to a CatShow page with information for that cat